### PR TITLE
Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/bundle
+Gemfile.lock
 
 # rspec failure tracking
 .rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,22 @@
+AllCops:
+  DisplayCopNames: true
+  TargetRubyVersion: 2.5
+  Exclude:
+    - 'bin/**/*'
+    - 'vendor/**/*'
+Documentation:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
+Metrics/LineLength:
+  Max: 130
+Metrics/MethodLength:
+  Max: 25
+Metrics/AbcSize:
+  Max: 16
+Style/Lambda:
+  EnforcedStyle: literal

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,3 @@
+SimpleCov.start do
+  SimpleCov.minimum_coverage 100.00
+end

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
----
 sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.3
-before_install: gem install bundler -v 2.0.1
+  - 2.5.1
+before_install:
+  - gem install bundler -v 1.17.3
+install:
+  - bundle _1.17.3_ install

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amaabca/red

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in ama_logger.gemspec
 gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Jesse Doyle
+Copyright (c) 2019 Alberta Motor Association
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,43 +1,49 @@
-# AmaLogger
+# Ama::Logger
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ama_logger`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+This library implements AMA's standardized log format.
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'ama_logger'
+gem 'ama_logger', git: 'git@github.com:amaabca/ama_logger'
 ```
-
-And then execute:
-
-    $ bundle
-
-Or install it yourself as:
-
-    $ gem install ama_logger
 
 ## Usage
 
-TODO: Write usage instructions here
+A default logger instance that writes to `STDOUT` is provided via the `Ama.logger` method:
 
-## Development
+```ruby
+Ama.logger.info(context: context, event_name: 'log.info', metric_name: 'test', metric_value: 1)
+```
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+You can override the default logger instance if you wish:
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+```ruby
+Ama.logger = Ama::Logger.lambda(STDERR, level: Logger::Severity::DEBUG)
+```
+
+The default `logger` instance is intended for use with AWS Lambda - it requires a `context` instance (from a [Lambda handler](https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html)) to be passed as well as any additional data.
+
+Instead of passing a log string, you must pass a `Hash` of data:
+
+```ruby
+Ama.logger.info(
+  context: context,                             # required - the Lambda context instance
+  event_name: 'log.info',                       # required
+  exception: 'ArgumentError - something broke', # optional - indexed
+  metric_name: 'error:count',                   # optional - indexed
+  metric_value: 1,                              # optional - indexed, coerced to integer
+  metric_content: 'error',                      # optional - indexed, coerced to string
+  details: { message: 'test' }                  # optional - non-indexed, Hash coerced to string
+)
+```
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/ama_logger. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/amaabca/ama_logger.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-## Code of Conduct
-
-Everyone interacting in the AmaLogger project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/[USERNAME]/ama_logger/blob/master/CODE_OF_CONDUCT.md).

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: %i[spec rubocop]
+
+RuboCop::RakeTask.new

--- a/ama_logger.gemspec
+++ b/ama_logger.gemspec
@@ -1,42 +1,55 @@
+# frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "ama_logger/version"
+require 'ama/logger/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "ama_logger"
-  spec.version       = AmaLogger::VERSION
-  spec.authors       = ["Jesse Doyle"]
-  spec.email         = ["jesse.doyle@ama.ab.ca"]
+  spec.name = 'ama_logger'
+  spec.version = Ama::Logger::VERSION
+  spec.authors = [
+    'Jesse Doyle',
+    'Michael van den Beuken',
+    'Darko Dosenovic',
+    'Zoie Carnegie'
+  ]
+  spec.email = [
+    'jesse.doyle@ama.ab.ca',
+    'michael.vandenbeuken@ama.ab.ca',
+    'darko.dosenovic@ama.ab.ca',
+    'zoie.carnegie@ama.ab.ca'
+  ]
+  spec.required_ruby_version = '>= 2.3.1'
+  spec.summary = 'Implementation of AMA\'s standard logging format'
+  spec.description = 'Log formatters and helper classes for the AMA standardized log format'
+  spec.homepage = 'https://github.com/amaabca/ama_logger'
+  spec.license = 'MIT'
 
-  spec.summary       = %q{TODO: Write a short summary, because RubyGems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
-  spec.license       = "MIT"
-
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the
+  # 'allowed_push_host' to allow pushing to a single host or delete this section
+  # to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
-
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "TODO: Put your gem's public repo URL here."
-    spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+    spec.metadata['allowed_push_host'] = ''
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  # The `git ls-files -z` loads the files in the RubyGem that have been added
+  # into git.
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    git_files = `git ls-files -z`.split("\x0")
+    git_files.reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'factory_bot'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '0.65.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/ama/logger.rb
+++ b/lib/ama/logger.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative 'logger/base'
+
+module Ama
+  # global logger instance initialization
+  # usage:
+  #
+  # Ama.logger.info(context: context, event_name: 'test')
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Logger.lambda
+    end
+  end
+
+  module Logger
+    AGENT_VERSION = "ama_logger:#{Ama::Logger::VERSION}"
+
+    class << self
+      def root
+        Pathname.new(Gem.loaded_specs['ama_logger'].full_gem_path)
+      end
+
+      def lambda(io = STDOUT, *args)
+        ::Logger.new(io, *args).tap do |instance|
+          instance.formatter = Ama::Logger::Formatter::Lambda.new
+        end
+      end
+    end
+  end
+end

--- a/lib/ama/logger/base.rb
+++ b/lib/ama/logger/base.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'time'
+require 'logger'
+require 'pathname'
+
+require_relative 'version'
+require_relative 'formatter/lambda'

--- a/lib/ama/logger/formatter/lambda.rb
+++ b/lib/ama/logger/formatter/lambda.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Ama
+  module Logger
+    module Formatter
+      class Lambda
+        def call(severity, time, _progname, msg = {})
+          invalid_argument!(:msg, Hash, msg) unless msg.is_a?(Hash)
+
+          context = msg.fetch(:context) { missing_argument!(:context) }
+          event_name = msg.fetch(:event_name) { missing_argument!(:event_name) }
+
+          {
+            exception: msg[:exception],
+            eventName: event_name,
+            eventSource: context.invoked_function_arn,
+            eventId: context.aws_request_id,
+            eventAgent: Ama::Logger::AGENT_VERSION,
+            details: details(msg),
+            indexed: indexed(msg),
+            severity: severity,
+            timestamp: time.utc.iso8601
+          }
+            .compact
+            .to_json
+        end
+
+        private
+
+        def details(data = {})
+          data.fetch(:details) { {} }.to_json
+        end
+
+        def indexed(opts = {})
+          data = opts.slice(:metric_name, :metric_value, :metric_content)
+
+          {
+            metricName: data[:metric_name]&.to_s,
+            metricValue: data[:metric_value]&.to_i,
+            metricContent: data[:metric_content]&.to_s
+          }
+            .compact
+        end
+
+        def missing_argument!(name)
+          raise ArgumentError, "must pass the `#{name}` argument"
+        end
+
+        def invalid_argument!(name, klass, value)
+          raise ArgumentError, "expected type `#{klass.inspect}` for argument `#{name}` - got `#{value.inspect}`"
+        end
+      end
+    end
+  end
+end

--- a/lib/ama/logger/version.rb
+++ b/lib/ama/logger/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Ama
+  module Logger
+    VERSION = '1.0.0'
+  end
+end

--- a/lib/ama_logger.rb
+++ b/lib/ama_logger.rb
@@ -1,6 +1,3 @@
-require "ama_logger/version"
+# frozen_string_literal: true
 
-module AmaLogger
-  class Error < StandardError; end
-  # Your code goes here...
-end
+require_relative 'ama/logger'

--- a/lib/ama_logger/version.rb
+++ b/lib/ama_logger/version.rb
@@ -1,3 +1,0 @@
-module AmaLogger
-  VERSION = "0.1.0"
-end

--- a/spec/ama/logger/formatter/lambda_spec.rb
+++ b/spec/ama/logger/formatter/lambda_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+describe Ama::Logger::Formatter::Lambda do
+  describe '#call' do
+    let(:time) { Time.now }
+
+    context 'when called with a string `msg` parameter' do
+      it 'raises ArgumentError' do
+        expect { subject.call('INFO', time, nil, 'test') }.to raise_error(
+          ArgumentError,
+          /expected type `Hash`/
+        )
+      end
+    end
+
+    context 'when called with a Hash `msg` parameter' do
+      context 'without providing a :context value' do
+        it 'raises ArgumentError' do
+          expect { subject.call('INFO', time, nil, {}) }.to raise_error(
+            ArgumentError,
+            /must pass the `context` argument/
+          )
+        end
+      end
+
+      context 'with the :context parameter' do
+        let(:context) { FactoryBot.build(:context) }
+
+        context 'without the :event_name parameter' do
+          it 'raises ArgumentError' do
+            expect { subject.call('INFO', time, nil, context: context) }.to raise_error(
+              ArgumentError,
+              /must pass the `event_name` argument/
+            )
+          end
+        end
+
+        context 'with the :event_name parameter' do
+          let(:msg) do
+            {
+              context: context,
+              event_name: 'log.info',
+              exception: 'FakeError: something failed',
+              metric_name: 'error_count',
+              metric_value: '1',
+              metric_content: 'test@example.com',
+              details: {
+                errors: ['there was a problem']
+              }
+            }
+          end
+          let(:entry) { subject.call('INFO', time, nil, msg) }
+          let(:parsed) { JSON.parse(entry) }
+
+          it 'returns a string' do
+            expect(entry).to be_a(String)
+          end
+
+          it 'includes the event name' do
+            expect(parsed['eventName']).to eq('log.info')
+          end
+
+          it 'includes the exception message' do
+            expect(parsed['exception']).to include('FakeError')
+          end
+
+          it 'includes the severity' do
+            expect(parsed['severity']).to eq('INFO')
+          end
+
+          it 'includes the indexed metrics' do
+            expect(parsed.dig('indexed', 'metricName')).to eq('error_count')
+            expect(parsed.dig('indexed', 'metricValue')).to eq(1)
+            expect(parsed.dig('indexed', 'metricContent')).to eq('test@example.com')
+          end
+
+          it 'stringifies the details Hash' do
+            expect(parsed['details']).to eq('{"errors":["there was a problem"]}')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/ama/logger_spec.rb
+++ b/spec/ama/logger_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe Ama::Logger do
+  describe '.root' do
+    it 'returns the root pathname to the gem' do
+      expect(described_class.root).to be_a(Pathname)
+    end
+  end
+
+  describe '.lambda' do
+    it 'returns a new Logger instance' do
+      expect(described_class.lambda).to be_a(Logger)
+    end
+
+    it 'accepts parameters' do
+      logger = described_class.lambda(StringIO.new, progname: 'test', level: Logger::Severity::DEBUG)
+      expect(logger.level).to eq(Logger::Severity::DEBUG)
+    end
+  end
+end

--- a/spec/ama_logger_spec.rb
+++ b/spec/ama_logger_spec.rb
@@ -1,9 +1,0 @@
-RSpec.describe AmaLogger do
-  it "has a version number" do
-    expect(AmaLogger::VERSION).not_to be nil
-  end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
-end

--- a/spec/ama_spec.rb
+++ b/spec/ama_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+describe Ama do
+  describe '.logger' do
+    it 'returns a Logger instance' do
+      expect(described_class.logger).to be_a(Logger)
+    end
+  end
+end

--- a/spec/factories/contexts.rb
+++ b/spec/factories/contexts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :context, class: OpenStruct do
+    invoked_function_arn { 'arn:aws:lambda:us-west-2:111111111111:function:testfunc' }
+    aws_request_id { SecureRandom.uuid }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,14 +1,26 @@
-require "bundler/setup"
-require "ama_logger"
+# frozen_string_literal: true
+
+require 'simplecov'
+require 'bundler/setup'
+require 'ama/logger'
+require 'ostruct'
+require 'factory_bot'
+require 'rspec'
+require 'pry'
+
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+Ama.logger = Ama::Logger.lambda(StringIO.new)
 
 RSpec.configure do |config|
-  # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.include FactoryBot::Syntax::Methods
 
-  # Disable RSpec exposing methods globally on `Module` and `main`
-  config.disable_monkey_patching!
+  config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
   end
 end


### PR DESCRIPTION
* Create a basic 1.0.0 implementation that includes an
  application-global `Ama.logger` instance that logs to
  standard out.
* Add a formatted for AWS Lambda logging that allows us
  to specify details and log to the standardized JSON
  log payload.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/3551