### PR TITLE
Trailing Newline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 25
 Metrics/AbcSize:
-  Max: 16
+  Max: 17
 Style/Lambda:
   EnforcedStyle: literal

--- a/lib/ama/logger/formatter/lambda.rb
+++ b/lib/ama/logger/formatter/lambda.rb
@@ -23,6 +23,7 @@ module Ama
           }
             .compact
             .to_json
+            .concat("\n")
         end
 
         private

--- a/lib/ama/logger/version.rb
+++ b/lib/ama/logger/version.rb
@@ -2,6 +2,6 @@
 
 module Ama
   module Logger
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/spec/ama/logger/formatter/lambda_spec.rb
+++ b/spec/ama/logger/formatter/lambda_spec.rb
@@ -56,6 +56,10 @@ describe Ama::Logger::Formatter::Lambda do
             expect(entry).to be_a(String)
           end
 
+          it 'has a trailing newline' do
+            expect(entry[-1]).to eq("\n")
+          end
+
           it 'includes the event name' do
             expect(parsed['eventName']).to eq('log.info')
           end


### PR DESCRIPTION
* All log messages were being concatenated onto the same line.
* Append a newline character to each log message so that it's
  more easily read in logs.
* Update the bugfix version as this is a non-breaking change.