### PR TITLE
ADO-3799 - Rails Log Filtering

### DIFF
--- a/lib/ama/logger.rb
+++ b/lib/ama/logger.rb
@@ -28,6 +28,13 @@ module Ama
           instance.formatter = Ama::Logger::Formatter::Lambda.new
         end
       end
+
+      def stringified_hash(base, opts = {})
+        base.dup.tap do |instance|
+          instance.formatter = Ama::Logger::Formatter::StringifiedHash.new(opts)
+          instance.progname = opts[:progname]
+        end
+      end
     end
   end
 end

--- a/lib/ama/logger/base.rb
+++ b/lib/ama/logger/base.rb
@@ -4,6 +4,8 @@ require 'json'
 require 'time'
 require 'logger'
 require 'pathname'
+require 'securerandom'
 
 require_relative 'version'
 require_relative 'formatter/lambda'
+require_relative 'formatter/stringified_hash'

--- a/lib/ama/logger/formatter/stringified_hash.rb
+++ b/lib/ama/logger/formatter/stringified_hash.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Ama
+  module Logger
+    module Formatter
+      class StringifiedHash
+        attr_accessor :filters, :regex, :event_name
+
+        def initialize(opts = {})
+          self.filters = opts.fetch(:filters) { [] }
+                             .select { |p| p.is_a?(Symbol) || p.is_a?(String) }
+                             .map(&:to_s)
+                             .join('|')
+          self.regex = /:(?<name>#{filters})=>"(?<value>[^"]*)"/
+          self.event_name = opts.fetch(:event_name) { 'log.rails' }
+        end
+
+        def call(severity, time, progname, msg)
+          {
+            eventName: event_name,
+            eventSource: progname || self.class.name,
+            eventId: SecureRandom.uuid,
+            eventAgent: Ama::Logger::AGENT_VERSION,
+            severity: severity,
+            details: msg.gsub(regex, ':\k<name>=>"[FILTERED]"'),
+            timestamp: time.utc.iso8601
+          }
+            .compact
+            .to_json
+            .concat("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/ama/logger/version.rb
+++ b/lib/ama/logger/version.rb
@@ -2,6 +2,6 @@
 
 module Ama
   module Logger
-    VERSION = '1.0.1'
+    VERSION = '1.1.0'
   end
 end

--- a/spec/ama/logger/formatter/stringified_hash_spec.rb
+++ b/spec/ama/logger/formatter/stringified_hash_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+describe Ama::Logger::Formatter::StringifiedHash do
+  subject do
+    described_class.new(
+      filters: %i[
+        access_token
+        password
+      ],
+      event_name: 'rails.activejob'
+    )
+  end
+
+  describe '#call' do
+    let(:message) do
+      'Enqueued DeleteApiHouseholdCacheJob ' \
+        '(Job ID: f454e3dd-9d34-496a-a0e2-aee5e69f3025) to ' \
+        'Shoryuken(gatekeeper-sqs-dev-Queue-123) with arguments: ' \
+        '{:access_token=>"1111-111-111-1111",:id=>"1234",:password=>"secr3t"}'
+    end
+    let(:sanitized) do
+      'Enqueued DeleteApiHouseholdCacheJob ' \
+        '(Job ID: f454e3dd-9d34-496a-a0e2-aee5e69f3025) to ' \
+        'Shoryuken(gatekeeper-sqs-dev-Queue-123) with arguments: ' \
+        '{:access_token=>"[FILTERED]",:id=>"1234",:password=>"[FILTERED]"}'
+    end
+    let(:payload) { subject.call('INFO', Time.now, nil, message) }
+    let(:data) { JSON.parse(payload) }
+
+    it 'filters out sensitive parameters from strings' do
+      expect(data['details']).to eq(sanitized)
+    end
+
+    it 'includes the specified event name' do
+      expect(payload).to include('rails.activejob')
+    end
+  end
+end

--- a/spec/ama/logger_spec.rb
+++ b/spec/ama/logger_spec.rb
@@ -17,4 +17,30 @@ describe Ama::Logger do
       expect(logger.level).to eq(Logger::Severity::DEBUG)
     end
   end
+
+  describe '.stringified_hash' do
+    let(:base) { Logger.new(StringIO.new) }
+
+    subject do
+      described_class.stringified_hash(
+        base,
+        filters: [:password],
+        event_name: 'test',
+        progname: 'program'
+      )
+    end
+
+    it 'returns a new Logger instance' do
+      expect(subject.object_id).to_not eq(base.object_id)
+      expect(subject).to be_a(Logger)
+    end
+
+    it 'sets the formatter as a StringifiedHash formatter' do
+      expect(subject.formatter).to be_a(Ama::Logger::Formatter::StringifiedHash)
+    end
+
+    it 'sets the progname attribute' do
+      expect(subject.progname).to eq('program')
+    end
+  end
 end


### PR DESCRIPTION
* There are many instances where Rails may log sensitive data
  (i.e. access_token) that are not caught by the standard
  parameter filter. For example, the default activejob logger
  will log all job parameters as a stringified hash in plaintext.
* Add an Ama::Logger::Formatter::StringifiedHash class that
  accepts parameter names and filters out the parameter values
  in the ruby stringified Hash syntax (i.e. `{test: '1234'}.inspect`.
* Add a helper method `Ama::Logger.stringified_hash(args)` that
  allows an easy override for the default loggers in Rails.
* Revamp the README to include a section outlining the individual
  formatters.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/3799