### PR TITLE
ADO-6266 - JSON Formatter

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,6 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 25
 Metrics/AbcSize:
-  Max: 17
+  Max: 20
 Style/Lambda:
   EnforcedStyle: literal

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This library includes the following custom log formatters:
 
 ### Ama::Logger::Formatter::Lambda
 
-This formatter accepts a Ruby hash as a message and outputs a JSON string.
+This formatter accepts a Ruby hash as a message, an AWS Lambda context instance and outputs a JSON string.
 
 The input hash must look like:
 
@@ -40,6 +40,25 @@ The input hash must look like:
 Ama.logger.info(
   context: context,                             # required - the Lambda context instance (https://docs.aws.amazon.com/lambda/latest/dg/ruby-context.html)
   event_name: 'log.info',                       # required
+  exception: 'ArgumentError - something broke', # optional - indexed
+  metric_name: 'error:count',                   # optional - indexed
+  metric_value: 1,                              # optional - indexed, coerced to integer
+  metric_content: 'error',                      # optional - indexed, coerced to string
+  details: { message: 'test' }                  # optional - non-indexed, Hash coerced to string
+)
+```
+
+### Ama::Logger::Formatter::Json
+
+This formatter accepts a Ruby hash as a message and outputs a JSON string.
+
+The input hash must look like:
+
+```ruby
+Ama.logger.info(
+  event_name: 'log.info',                       # required
+  event_id: '1234',                             # required - indexed
+  event_source: 'my_source',                    # required - indexed
   exception: 'ArgumentError - something broke', # optional - indexed
   metric_name: 'error:count',                   # optional - indexed
   metric_value: 1,                              # optional - indexed, coerced to integer

--- a/lib/ama/logger.rb
+++ b/lib/ama/logger.rb
@@ -29,6 +29,12 @@ module Ama
         end
       end
 
+      def json(io = STDOUT, *args)
+        ::Logger.new(io, *args).tap do |instance|
+          instance.formatter = Ama::Logger::Formatter::Json.new
+        end
+      end
+
       def stringified_hash(base, opts = {})
         base.dup.tap do |instance|
           instance.formatter = Ama::Logger::Formatter::StringifiedHash.new(opts)

--- a/lib/ama/logger/base.rb
+++ b/lib/ama/logger/base.rb
@@ -8,4 +8,5 @@ require 'securerandom'
 
 require_relative 'version'
 require_relative 'formatter/lambda'
+require_relative 'formatter/json'
 require_relative 'formatter/stringified_hash'

--- a/lib/ama/logger/formatter/json.rb
+++ b/lib/ama/logger/formatter/json.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Ama
+  module Logger
+    module Formatter
+      class Json
+        def call(severity, time, _progname, msg = {})
+          invalid_argument!(:msg, Hash, msg) unless msg.is_a?(Hash)
+
+          event_name = msg.fetch(:event_name) { missing_argument!(:event_name) }
+          event_source = msg.fetch(:event_source) { missing_argument!(:event_source) }
+          event_id = msg.fetch(:event_id) { missing_argument!(:event_id) }
+
+          {
+            exception: msg[:exception],
+            eventName: event_name,
+            eventSource: event_source.to_s,
+            eventId: event_id.to_s,
+            eventAgent: Ama::Logger::AGENT_VERSION,
+            details: details(msg),
+            indexed: indexed(msg),
+            severity: severity,
+            timestamp: time.utc.iso8601
+          }
+            .compact
+            .to_json
+            .concat("\n")
+        end
+
+        private
+
+        def details(data = {})
+          data.fetch(:details) { {} }.to_json
+        end
+
+        def indexed(opts = {})
+          data = opts.slice(:metric_name, :metric_value, :metric_content)
+
+          {
+            metricName: data[:metric_name]&.to_s,
+            metricValue: data[:metric_value]&.to_i,
+            metricContent: data[:metric_content]&.to_s
+          }
+            .compact
+        end
+
+        def missing_argument!(name)
+          raise ArgumentError, "must pass the `#{name}` argument"
+        end
+
+        def invalid_argument!(name, klass, value)
+          raise ArgumentError, "expected type `#{klass.inspect}` for argument `#{name}` - got `#{value.inspect}`"
+        end
+      end
+    end
+  end
+end

--- a/lib/ama/logger/version.rb
+++ b/lib/ama/logger/version.rb
@@ -2,6 +2,6 @@
 
 module Ama
   module Logger
-    VERSION = '1.1.1'
+    VERSION = '1.2.0'
   end
 end

--- a/spec/ama/logger/formatter/json_spec.rb
+++ b/spec/ama/logger/formatter/json_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+describe Ama::Logger::Formatter::Json do
+  describe '#call' do
+    let(:time) { Time.now }
+
+    context 'when called with a string `msg` parameter' do
+      it 'raises ArgumentError' do
+        expect { subject.call('INFO', time, nil, 'test') }.to raise_error(
+          ArgumentError,
+          /expected type `Hash`/
+        )
+      end
+    end
+
+    context 'when called with a Hash `msg` parameter' do
+      context 'without the :event_name parameter' do
+        it 'raises ArgumentError' do
+          expect { subject.call('INFO', time, nil, event_id: '1', event_source: 'test') }.to raise_error(
+            ArgumentError,
+            /must pass the `event_name` argument/
+          )
+        end
+      end
+
+      context 'without the :event_id parameter' do
+        it 'raises ArgumentError' do
+          expect { subject.call('INFO', time, nil, event_name: 'test', event_source: 'test') }.to raise_error(
+            ArgumentError,
+            /must pass the `event_id` argument/
+          )
+        end
+      end
+
+      context 'without the :event_source parameter' do
+        it 'raises ArgumentError' do
+          expect { subject.call('INFO', time, nil, event_name: 'test', event_id: '1') }.to raise_error(
+            ArgumentError,
+            /must pass the `event_source` argument/
+          )
+        end
+      end
+
+      context 'with valid parameters' do
+        let(:msg) do
+          {
+            event_name: 'log.info',
+            event_id: '1',
+            event_source: 'test',
+            exception: 'FakeError: something failed',
+            metric_name: 'error_count',
+            metric_value: '1',
+            metric_content: 'test@example.com',
+            details: {
+              errors: ['there was a problem']
+            }
+          }
+        end
+        let(:entry) { subject.call('INFO', time, nil, msg) }
+        let(:parsed) { JSON.parse(entry) }
+
+        it 'returns a string' do
+          expect(entry).to be_a(String)
+        end
+
+        it 'has a trailing newline' do
+          expect(entry[-1]).to eq("\n")
+        end
+
+        it 'includes the event name' do
+          expect(parsed['eventName']).to eq('log.info')
+        end
+
+        it 'includes the exception message' do
+          expect(parsed['exception']).to include('FakeError')
+        end
+
+        it 'includes the severity' do
+          expect(parsed['severity']).to eq('INFO')
+        end
+
+        it 'includes the indexed metrics' do
+          expect(parsed.dig('indexed', 'metricName')).to eq('error_count')
+          expect(parsed.dig('indexed', 'metricValue')).to eq(1)
+          expect(parsed.dig('indexed', 'metricContent')).to eq('test@example.com')
+        end
+
+        it 'stringifies the details Hash' do
+          expect(parsed['details']).to eq('{"errors":["there was a problem"]}')
+        end
+      end
+    end
+  end
+end

--- a/spec/ama/logger_spec.rb
+++ b/spec/ama/logger_spec.rb
@@ -16,6 +16,25 @@ describe Ama::Logger do
       logger = described_class.lambda(StringIO.new, progname: 'test', level: Logger::Severity::DEBUG)
       expect(logger.level).to eq(Logger::Severity::DEBUG)
     end
+
+    it 'has the correct formatter' do
+      expect(described_class.lambda.formatter).to be_a(Ama::Logger::Formatter::Lambda)
+    end
+  end
+
+  describe '.json' do
+    it 'returns a new Logger instance' do
+      expect(described_class.json).to be_a(Logger)
+    end
+
+    it 'accepts parameters' do
+      logger = described_class.json(StringIO.new, progname: 'test', level: Logger::Severity::DEBUG)
+      expect(logger.level).to eq(Logger::Severity::DEBUG)
+    end
+
+    it 'has the correct formatter' do
+      expect(described_class.json.formatter).to be_a(Ama::Logger::Formatter::Json)
+    end
   end
 
   describe '.stringified_hash' do


### PR DESCRIPTION
* Add a general (non-AWS lambda-related) JSON log formatted that
  can be used for applications outside of a lambda environment.
* This new formatter does not accept a `context` parameter, but
  instead requires `event_id` and `event_source` parameters for
  consistency.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/6266