### PR TITLE
ADO 9566: Dependency Updates

### DIFF
--- a/ama_logger.gemspec
+++ b/ama_logger.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 12.2'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.65.0'
   spec.add_development_dependency 'simplecov'

--- a/lib/ama/logger/version.rb
+++ b/lib/ama/logger/version.rb
@@ -2,6 +2,6 @@
 
 module Ama
   module Logger
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
See: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/9566

* bump minimum rake dev dependency (CVE-2020-8130)